### PR TITLE
questions

### DIFF
--- a/overview.c
+++ b/overview.c
@@ -1,7 +1,7 @@
 #define UNUSED(a) (void)a
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 #define MAX(a,b) ((a) < (b) ? (b) : (a))
-#define LEN(a) (sizeof(a)/sizeof(a)[0
+#define LEN(a) (sizeof(a)/sizeof(a)[0])
 
 static int
 overview(struct nk_context *ctx)
@@ -249,9 +249,9 @@ overview(struct nk_context *ctx)
                 nk_property_float(ctx, "#float:", range_float_min, &range_float_value, range_float_max, 1.0f, 0.2f);
                 nk_property_float(ctx, "#max:", range_float_min, &range_float_max, 100, 1.0f, 0.2f);
 
-                nk_property_int(ctx, "#min:", INT_MIN, &range_int_min, range_int_max, 1, 10);
+                nk_property_int(ctx, "#min:", INT8_MIN, &range_int_min, range_int_max, 1, 10);
                 nk_property_int(ctx, "#neg:", range_int_min, &range_int_value, range_int_max, 1, 10);
-                nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT_MAX, 1, 10);
+                nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT8_MAX, 1, 10);
 
                 nk_tree_pop(ctx);
             }

--- a/ultiboCgeneric.c
+++ b/ultiboCgeneric.c
@@ -28,11 +28,6 @@
 #define MAX_VERTEX_MEMORY 256 * 1024
 #define MAX_ELEMENT_MEMORY 64 * 1024
 
-#define UNUSED(a) (void)a
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#define MAX(a,b) ((a) < (b) ? (b) : (a))
-#define LEN(a) (sizeof(a)/sizeof(a)[0])
-
 #define NK_ULTIBO_GLES2_IMPLEMENTATION
 #include "nuklear/nuklear.h"
 #include "nuklear_ultibo_gles2.h"


### PR DESCRIPTION
These comments are in ultiboCgeneric.c 
	/*Mouse*/
	// needs a much better code
	// works for now
Is this why the mouse is not working in Ultibo?
	
overview.c
This is not part of nuklear/demo/overview.c.
What was the reason to add to ultibo_nuklear/overview.
#define UNUSED(a) (void)a
#define MIN(a,b) ((a) < (b) ? (a) : (b))
#define MAX(a,b) ((a) < (b) ? (b) : (a))
#define LEN(a) (sizeof(a)/sizeof(a)[0

This is what appears in ultiboCgeneric.c
ultiboCgeneric.c
#define UNUSED(a) (void)a
#define MIN(a,b) ((a) < (b) ? (a) : (b))
#define MAX(a,b) ((a) < (b) ? (b) : (a))
#define LEN(a) (sizeof(a)/sizeof(a)[0])

These are some of the errors before any changes to  overview.c

overview.c:4:0: warning: "LEN" redefined
 #define LEN(a) (sizeof(a)/sizeof(a)[0
 
overview.c:252:47: error: 'INT_MIN' undeclared (first use in this function); did you mean 'INT8_MIN'?

overview.c:254:78: error: 'INT_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
        nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT_MAX, 1, 10);
                                                                     ^~~~~~~
                                                                              INT8_MAX
The above errors are resolved with these changes overview.c.
 #define MAX(a,b) ((a) < (b) ? (b) : (a))
-#define LEN(a) (sizeof(a)/sizeof(a)[0
+#define LEN(a) (sizeof(a)/sizeof(a)[0])
 
 static int
 overview(struct nk_context *ctx)
@@ -249,9 +249,9 @@ overview(struct nk_context *ctx)
                 nk_property_float(ctx, "#float:", range_float_min, &range_float_value, range_float_max, 1.0f, 0.2f);
                 nk_property_float(ctx, "#max:", range_float_min, &range_float_max, 100, 1.0f, 0.2f);
 
-                nk_property_int(ctx, "#min:", INT_MIN, &range_int_min, range_int_max, 1, 10);
+                nk_property_int(ctx, "#min:", INT8_MIN, &range_int_min, range_int_max, 1, 10);
                 nk_property_int(ctx, "#neg:", range_int_min, &range_int_value, range_int_max, 1, 10);
-                nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT_MAX, 1, 10);
+                nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT8_MAX, 1, 10);

